### PR TITLE
Prepare for integration as module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ink-docstrap",
+  "name": "highcharts-docstrap",
   "version": "1.3.0",
   "decription": "A template for JSDoc3 based on Bootstrap and Bootswatch",
   "devDependencies": {
@@ -23,16 +23,13 @@
     "jsdoc3",
     "theme"
   ],
-  "author": {
-    "email": "me@terryweiss.net",
-    "name": "Terry Weiss"
-  },
+  "author": "Highsoft AS",
   "bugs": {
-    "url": "https://github.com/docstrap/docstrap/issues"
+    "url": "https://github.com/highcharts/highcharts-docstrap/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/docstrap/docstrap.git"
+    "url": "https://github.com/highcharts/highcharts-docstrap.git"
   },
   "main": "./template/publish.js",
   "dependencies": {


### PR DESCRIPTION
So we can add it as a devDependency in highcharts/package.json.